### PR TITLE
feat(compass): allow optional ID in CreateAssetProbeRequest

### DIFF
--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -1173,6 +1173,7 @@ message GetAssetByVersionResponse {
 
 message CreateAssetProbeRequest {
   message Probe {
+    string id = 5; // optional
     string status = 1 [
       (validate.rules).string = {
         min_len: 1,


### PR DESCRIPTION
In the `CreateAssetProbeRequest`, allow specifying the ID for the probe. If the ID is specified, it should be used as the probe ID. If it is not specified, the ID should be created automatically. The ID if specified, should be a valid UUID.