### PR TITLE
feat: add created_by & updated_by to resource

### DIFF
--- a/gotocompany/entropy/v1beta1/resource.proto
+++ b/gotocompany/entropy/v1beta1/resource.proto
@@ -119,9 +119,11 @@ message Resource {
   map<string, string> labels = 5;
   google.protobuf.Timestamp created_at = 6;
   google.protobuf.Timestamp updated_at = 7;
+  string created_by = 8;
+  string updated_by = 9;
 
-  ResourceSpec spec = 8;
-  ResourceState state = 9;
+  ResourceSpec spec = 10;
+  ResourceState state = 11;
 }
 
 message ListResourcesRequest {

--- a/gotocompany/entropy/v1beta1/resource.proto
+++ b/gotocompany/entropy/v1beta1/resource.proto
@@ -119,11 +119,12 @@ message Resource {
   map<string, string> labels = 5;
   google.protobuf.Timestamp created_at = 6;
   google.protobuf.Timestamp updated_at = 7;
-  string created_by = 8;
-  string updated_by = 9;
 
-  ResourceSpec spec = 10;
-  ResourceState state = 11;
+  ResourceSpec spec = 8;
+  ResourceState state = 9;
+
+  string created_by = 10;
+  string updated_by = 11;
 }
 
 message ListResourcesRequest {


### PR DESCRIPTION
Earlier creator information was set by the client. Which was not a reliable source, as the client may not set it.
Now we have a dedicated field inside resource object for creator and updator.