### PR TITLE
fix(optimus): replace window delay with shift by

### DIFF
--- a/gotocompany/optimus/core/v1beta1/job_spec.proto
+++ b/gotocompany/optimus/core/v1beta1/job_spec.proto
@@ -337,7 +337,8 @@ message JobSpecification {
   message Window {
     string preset = 1;
     string size = 2;
-    string delay = 3;
+    string delay = 3 [deprecated = true];
+    string shift_by = 6;
     string location = 4;
     string truncate_to = 5;
   }

--- a/gotocompany/optimus/core/v1beta1/project.proto
+++ b/gotocompany/optimus/core/v1beta1/project.proto
@@ -80,7 +80,8 @@ message ProjectSpecification {
     string truncate_to = 3;
     string offset = 4 [deprecated = true];
     string size = 5;
-    string delay = 6;
+    string delay = 6 [deprecated = true];
+    string shift_by = 8;
     string location = 7;
   }
   map<string, ProjectPreset> presets = 4;


### PR DESCRIPTION
The PR is to update the contract for window, where there is a need to do replacement for `delay` into `shift_by`. More detail is in the mentioned [PR](https://github.com/goto/optimus/pull/217) for Optimus.