### PR TITLE
feat(compass): add option to include/exclude attributes when getting …

### DIFF
--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -941,7 +941,7 @@ message GetGraphRequest {
       ""
     ]
   }];
-  bool with_attributes = 4;
+  optional bool with_attributes = 4;
 }
 
 message GetGraphResponse {

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -941,6 +941,7 @@ message GetGraphRequest {
       ""
     ]
   }];
+  bool with_attributes = 4;
 }
 
 message GetGraphResponse {


### PR DESCRIPTION
The purpose of this PR is to allow for optional attributes being returned when calling `GetGraph`.