### PR TITLE
feat(asset): create delete assets API in compass

### DIFF
--- a/gotocompany/assets/v1beta2/asset.proto
+++ b/gotocompany/assets/v1beta2/asset.proto
@@ -62,7 +62,7 @@ message Asset {
   // This information is expected to be maintained by the system.
   google.protobuf.Timestamp update_time = 102;
 
-  // The timestamp when the asset was last synced.
+  // The timestamp when the asset was last refreshed.
   // This information is expected to be maintained by the system.
   google.protobuf.Timestamp refreshed_at = 103;
 }

--- a/gotocompany/assets/v1beta2/asset.proto
+++ b/gotocompany/assets/v1beta2/asset.proto
@@ -61,4 +61,8 @@ message Asset {
   // The timestamp when the asset was last modified.
   // This information is expected to be maintained by the system.
   google.protobuf.Timestamp update_time = 102;
+
+  // The timestamp when the asset was last synced.
+  // This information is expected to be maintained by the system.
+  google.protobuf.Timestamp refreshed_at = 103;
 }

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -1162,36 +1162,15 @@ message DeleteAssetRequest {
 message DeleteAssetResponse {}
 
 message DeleteAssetsRequest {
-  string types = 1 [
-    (validate.rules).string.ignore_empty = true,
+  string query_expr = 1 [
+    (validate.rules).string.min_len = 3,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by multiple types"
+      description: "filter by query expr"
     }
   ];
-  string services = 2 [
-    (validate.rules).string.ignore_empty = true,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by multiple services"
-    }
-  ];
-  map<string, string> data = 3 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-    description: "query result based on a (nested) field of the data asset. the nested field is written with period separated field name. eg, \"data[name.entity]\""
-  }];
   bool dry_run = 4 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "if set to true, then deletion should not proceed and only return the affected rows. else, will perform deletion in the background"
-    }
-  ];
-  google.protobuf.Timestamp refreshed_at_upper_threshold = 11 [
-    (validate.rules).timestamp.required = true,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by refreshed_at <= duration_for_upper_threshold"
-    }
-  ];
-  google.protobuf.Timestamp refreshed_at_lower_threshold = 12 [
-    (validate.rules).timestamp.required = false,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by refreshed_at => duration_for_lower_threshold"
     }
   ];
 }

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -1165,7 +1165,7 @@ message DeleteAssetsRequest {
   string query_expr = 1 [
     (validate.rules).string.min_len = 3,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by query expr"
+      description: "filter by query expr, example: refreshed_at <= \"2024-08-05T23:59:59\""
     }
   ];
   bool dry_run = 4 [

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -1189,7 +1189,7 @@ message DeleteAssetsRequest {
     }
   ];
   google.protobuf.Duration duration_for_lower_threshold = 12 [
-    (validate.rules).duration.required = true,
+    (validate.rules).duration.required = false,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "filter by time field (e.g. refreshed_at, updated_at) => now - duration_for_lower_threshold"
     }

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -1203,7 +1203,7 @@ message DeleteAssetsRequest {
 }
 
 message DeleteAssetsResponse {
-  uint32 rows_affected = 7;
+  uint32 affected_rows = 1;
 }
 
 message GetAssetStargazersRequest {

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -1179,25 +1179,19 @@ message DeleteAssetsRequest {
   }];
   bool dry_run = 4 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "After returning the number of affected rows, should the deletion proceed or not (dry run)?"
+      description: "if set to true, then deletion should not proceed and only return the affected rows. else, will perform deletion in the background"
     }
   ];
   google.protobuf.Duration duration_for_upper_threshold = 11 [
     (validate.rules).duration.required = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by time field (e.g. refreshed_at, updated_at) <= now - duration_for_upper_threshold"
+      description: "filter by refreshed_at <= now - duration_for_upper_threshold"
     }
   ];
   google.protobuf.Duration duration_for_lower_threshold = 12 [
     (validate.rules).duration.required = false,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by time field (e.g. refreshed_at, updated_at) => now - duration_for_lower_threshold"
-    }
-  ];
-  string duration_comparison_by = 13 [
-    (validate.rules).string.ignore_empty = true,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "comparison field for duration_for_upper_threshold and duration_for_lower_threshold, e.g. refreshed_at, updated_at"
+      description: "filter by refreshed_at => now - duration_for_lower_threshold"
     }
   ];
 }

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -6,7 +6,6 @@ import "google/api/annotations.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
-import "google/protobuf/duration.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 import "validate/validate.proto";
 
@@ -1168,7 +1167,7 @@ message DeleteAssetsRequest {
       description: "filter by query expr, example: refreshed_at <= \"2024-08-05T23:59:59\""
     }
   ];
-  bool dry_run = 4 [
+  bool dry_run = 2 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "if set to true, then deletion should not proceed and only return the affected rows. else, will perform deletion in the background"
     }

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -1072,13 +1072,13 @@ message GetAllAssetsRequest {
   string duration_before_current = 11 [
     (validate.rules).string.ignore_empty = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by refreshed_at field > now - duration_before_current"
+      description: "filter by refreshed_at field < now - duration_before_current"
     }
   ];
   string duration_after_current = 12 [
     (validate.rules).string.ignore_empty = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by refreshed_at field < now - duration_before_current"
+      description: "filter by refreshed_at field > now - duration_before_current"
     }
   ];
 }
@@ -1203,13 +1203,13 @@ message DeleteAssetsRequest {
   string duration_before_current = 6 [
     (validate.rules).string.min_len = 1,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by refreshed_at field > now - duration_before_current"
+      description: "filter by refreshed_at field < now - duration_before_current"
     }
   ];
   string duration_after_current = 7 [
     (validate.rules).string.ignore_empty = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by refreshed_at field < now - duration_before_current"
+      description: "filter by refreshed_at field > now - duration_before_current"
     }
   ];
 }

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -6,6 +6,7 @@ import "google/api/annotations.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
+import "google/protobuf/duration.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 import "validate/validate.proto";
 
@@ -1176,14 +1177,19 @@ message DeleteAssetsRequest {
   map<string, string> filter = 3 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
     description: "filter result based on a (nested) field of the asset. the nested field is written with period separated field name. eg, \"filter[data.landscape]\""
   }];
-  string duration_for_upper_threshold = 11 [
-    (validate.rules).string.min_len = 1,
+  bool dry_run = 4 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "After returning the number of affected rows, should the deletion proceed or not (dry run)?"
+    }
+  ];
+  google.protobuf.Duration duration_for_upper_threshold = 11 [
+    (validate.rules).duration.required = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "filter by time field (e.g. refreshed_at, updated_at) < now - duration_for_upper_threshold"
     }
   ];
-  string duration_for_lower_threshold = 12 [
-    (validate.rules).string.ignore_empty = true,
+  google.protobuf.Duration duration_for_lower_threshold = 12 [
+    (validate.rules).duration.required = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "filter by time field (e.g. refreshed_at, updated_at) > now - duration_for_lower_threshold"
     }

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -1174,8 +1174,8 @@ message DeleteAssetsRequest {
       description: "filter by multiple services"
     }
   ];
-  map<string, string> filter = 3 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-    description: "filter result based on a (nested) field of the asset. the nested field is written with period separated field name. eg, \"filter[data.landscape]\""
+  map<string, string> data = 3 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+    description: "query result based on a (nested) field of the data asset. the nested field is written with period separated field name. eg, \"data[name.entity]\""
   }];
   bool dry_run = 4 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -1182,16 +1182,16 @@ message DeleteAssetsRequest {
       description: "if set to true, then deletion should not proceed and only return the affected rows. else, will perform deletion in the background"
     }
   ];
-  google.protobuf.Duration duration_for_upper_threshold = 11 [
-    (validate.rules).duration.required = true,
+  google.protobuf.Timestamp refreshed_at_upper_threshold = 11 [
+    (validate.rules).timestamp.required = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by refreshed_at <= now - duration_for_upper_threshold"
+      description: "filter by refreshed_at <= duration_for_upper_threshold"
     }
   ];
-  google.protobuf.Duration duration_for_lower_threshold = 12 [
-    (validate.rules).duration.required = false,
+  google.protobuf.Timestamp refreshed_at_lower_threshold = 12 [
+    (validate.rules).timestamp.required = false,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by refreshed_at => now - duration_for_lower_threshold"
+      description: "filter by refreshed_at => duration_for_lower_threshold"
     }
   ];
 }

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -1194,19 +1194,19 @@ message DeleteAssetsRequest {
   map<string, string> filter = 3 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
     description: "filter result based on a (nested) field of the asset. the nested field is written with period separated field name. eg, \"filter[data.landscape]\""
   }];
-  string duration_for_upper_threshold = 6 [
+  string duration_for_upper_threshold = 11 [
     (validate.rules).string.min_len = 1,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "filter by time field (e.g. refreshed_at, updated_at) < now - duration_for_upper_threshold"
     }
   ];
-  string duration_for_lower_threshold = 7 [
+  string duration_for_lower_threshold = 12 [
     (validate.rules).string.ignore_empty = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "filter by time field (e.g. refreshed_at, updated_at) > now - duration_for_lower_threshold"
     }
   ];
-  string duration_comparison_by = 8 [
+  string duration_comparison_by = 13 [
     (validate.rules).string.ignore_empty = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "comparison field for duration_for_upper_threshold and duration_for_lower_threshold, e.g. refreshed_at, updated_at"

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -1185,13 +1185,13 @@ message DeleteAssetsRequest {
   google.protobuf.Duration duration_for_upper_threshold = 11 [
     (validate.rules).duration.required = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by time field (e.g. refreshed_at, updated_at) < now - duration_for_upper_threshold"
+      description: "filter by time field (e.g. refreshed_at, updated_at) <= now - duration_for_upper_threshold"
     }
   ];
   google.protobuf.Duration duration_for_lower_threshold = 12 [
     (validate.rules).duration.required = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by time field (e.g. refreshed_at, updated_at) > now - duration_for_lower_threshold"
+      description: "filter by time field (e.g. refreshed_at, updated_at) => now - duration_for_lower_threshold"
     }
   ];
   string duration_comparison_by = 13 [

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -348,12 +348,13 @@ service CompassService {
 
   rpc DeleteAssets(DeleteAssetsRequest) returns (DeleteAssetsResponse) {
     option (google.api.http) = {
-      delete: "/v1beta1/assets"
+      post: "/v1beta1/assets/delete-by-query"
+      body: "*"
     };
 
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Delete assets";
-      description: "Delete all assets that match with specified filter";
+      description: "Delete all assets that match with specified query expr";
       tags: [
         "Asset"
       ];

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -1179,32 +1179,20 @@ message DeleteAssetRequest {
 message DeleteAssetResponse {}
 
 message DeleteAssetsRequest {
-  string q = 1 [
-    (validate.rules).string.ignore_empty = true,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by specific query"
-    }
-  ];
-  string q_fields = 2 [
-    (validate.rules).string.ignore_empty = true,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by multiple query fields"
-    }
-  ];
-  string types = 3 [
+  string types = 1 [
     (validate.rules).string.ignore_empty = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "filter by multiple types"
     }
   ];
-  string services = 4 [
+  string services = 2 [
     (validate.rules).string.ignore_empty = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "filter by multiple services"
     }
   ];
-  map<string, string> data = 5 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-    description: "query result based on a (nested) field of the data asset. the nested field is written with period separated field name. eg, \"data[name.entity]\""
+  map<string, string> filter = 3 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+    description: "filter result based on a (nested) field of the asset. the nested field is written with period separated field name. eg, \"filter[data.landscape]\""
   }];
   string duration_for_upper_threshold = 6 [
     (validate.rules).string.min_len = 1,
@@ -1227,7 +1215,7 @@ message DeleteAssetsRequest {
 }
 
 message DeleteAssetsResponse {
-  uint32 row_affected = 7;
+  uint32 rows_affected = 7;
 }
 
 message GetAssetStargazersRequest {

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -856,7 +856,7 @@ message SearchAssetsRequest {
     }
   ];
 
-  SearchFlags flags = 8 [ (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+  SearchFlags flags = 8 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
     description: "flags to control the search behavior (e.g. column level search, disable fuzzy, etc)"
   }];
 }
@@ -915,15 +915,15 @@ message SearchFlags {
       title: "SearchFlags"
     }
   };
-  bool is_column_search = 1 [ (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+  bool is_column_search = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
     description: "search column names instead of table urn or name."
   }];
 
-  bool disable_fuzzy = 2 [ (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+  bool disable_fuzzy = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
     description: "disable fuzzy search."
   }];
 
-  bool enable_highlight = 3 [ (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+  bool enable_highlight = 3 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
     description: "enable highlight in search response."
   }];
 }
@@ -1069,16 +1069,22 @@ message GetAllAssetsRequest {
   bool with_total = 10 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
     description: "if set include total field in response"
   }];
-  string duration_before_current = 11 [
+  string duration_for_upper_threshold = 11 [
     (validate.rules).string.ignore_empty = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by refreshed_at field < now - duration_before_current"
+      description: "filter by time field (e.g. refreshed_at, updated_at) < now - duration_for_upper_threshold"
     }
   ];
-  string duration_after_current = 12 [
+  string duration_for_lower_threshold = 12 [
     (validate.rules).string.ignore_empty = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by refreshed_at field > now - duration_before_current"
+      description: "filter by time field (e.g. refreshed_at, updated_at) > now - duration_for_lower_threshold"
+    }
+  ];
+  string duration_comparison_by = 13 [
+    (validate.rules).string.ignore_empty = true,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "comparison field for duration_for_upper_threshold and duration_for_lower_threshold, e.g. refreshed_at, updated_at"
     }
   ];
 }
@@ -1200,21 +1206,29 @@ message DeleteAssetsRequest {
   map<string, string> data = 5 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
     description: "query result based on a (nested) field of the data asset. the nested field is written with period separated field name. eg, \"data[name.entity]\""
   }];
-  string duration_before_current = 6 [
+  string duration_for_upper_threshold = 6 [
     (validate.rules).string.min_len = 1,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by refreshed_at field < now - duration_before_current"
+      description: "filter by time field (e.g. refreshed_at, updated_at) < now - duration_for_upper_threshold"
     }
   ];
-  string duration_after_current = 7 [
+  string duration_for_lower_threshold = 7 [
     (validate.rules).string.ignore_empty = true,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by refreshed_at field > now - duration_before_current"
+      description: "filter by time field (e.g. refreshed_at, updated_at) > now - duration_for_lower_threshold"
+    }
+  ];
+  string duration_comparison_by = 8 [
+    (validate.rules).string.ignore_empty = true,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "comparison field for duration_for_upper_threshold and duration_for_lower_threshold, e.g. refreshed_at, updated_at"
     }
   ];
 }
 
-message DeleteAssetsResponse {}
+message DeleteAssetsResponse {
+  uint32 row_affected = 7;
+}
 
 message GetAssetStargazersRequest {
   string id = 1;

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -1069,24 +1069,6 @@ message GetAllAssetsRequest {
   bool with_total = 10 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
     description: "if set include total field in response"
   }];
-  string duration_for_upper_threshold = 11 [
-    (validate.rules).string.ignore_empty = true,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by time field (e.g. refreshed_at, updated_at) < now - duration_for_upper_threshold"
-    }
-  ];
-  string duration_for_lower_threshold = 12 [
-    (validate.rules).string.ignore_empty = true,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "filter by time field (e.g. refreshed_at, updated_at) > now - duration_for_lower_threshold"
-    }
-  ];
-  string duration_comparison_by = 13 [
-    (validate.rules).string.ignore_empty = true,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "comparison field for duration_for_upper_threshold and duration_for_lower_threshold, e.g. refreshed_at, updated_at"
-    }
-  ];
 }
 
 message GetAllAssetsResponse {

--- a/gotocompany/compass/v1beta1/service.proto
+++ b/gotocompany/compass/v1beta1/service.proto
@@ -346,6 +346,20 @@ service CompassService {
     };
   }
 
+  rpc DeleteAssets(DeleteAssetsRequest) returns (DeleteAssetsResponse) {
+    option (google.api.http) = {
+      delete: "/v1beta1/assets"
+    };
+
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Delete assets";
+      description: "Delete all assets that match with specified filter";
+      tags: [
+        "Asset"
+      ];
+    };
+  }
+
   rpc GetAssetStargazers(GetAssetStargazersRequest) returns (GetAssetStargazersResponse) {
     option (google.api.http) = {
       get: "/v1beta1/assets/{id}/stargazers"
@@ -1055,6 +1069,18 @@ message GetAllAssetsRequest {
   bool with_total = 10 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
     description: "if set include total field in response"
   }];
+  string duration_before_current = 11 [
+    (validate.rules).string.ignore_empty = true,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "filter by refreshed_at field > now - duration_before_current"
+    }
+  ];
+  string duration_after_current = 12 [
+    (validate.rules).string.ignore_empty = true,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "filter by refreshed_at field < now - duration_before_current"
+    }
+  ];
 }
 
 message GetAllAssetsResponse {
@@ -1145,6 +1171,50 @@ message DeleteAssetRequest {
 }
 
 message DeleteAssetResponse {}
+
+message DeleteAssetsRequest {
+  string q = 1 [
+    (validate.rules).string.ignore_empty = true,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "filter by specific query"
+    }
+  ];
+  string q_fields = 2 [
+    (validate.rules).string.ignore_empty = true,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "filter by multiple query fields"
+    }
+  ];
+  string types = 3 [
+    (validate.rules).string.ignore_empty = true,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "filter by multiple types"
+    }
+  ];
+  string services = 4 [
+    (validate.rules).string.ignore_empty = true,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "filter by multiple services"
+    }
+  ];
+  map<string, string> data = 5 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+    description: "query result based on a (nested) field of the data asset. the nested field is written with period separated field name. eg, \"data[name.entity]\""
+  }];
+  string duration_before_current = 6 [
+    (validate.rules).string.min_len = 1,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "filter by refreshed_at field > now - duration_before_current"
+    }
+  ];
+  string duration_after_current = 7 [
+    (validate.rules).string.ignore_empty = true,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "filter by refreshed_at field < now - duration_before_current"
+    }
+  ];
+}
+
+message DeleteAssetsResponse {}
 
 message GetAssetStargazersRequest {
   string id = 1;

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.17'
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.4.7"
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.28.2"
         classpath "org.ajoberstar:gradle-git:1.6.0"
     }
 }
@@ -47,11 +47,21 @@ dependencies {
 protobuf {
     generatedFilesBaseDir = "${projectDir}/build/protos/"
     protoc {
-        artifact = "com.google.protobuf:protoc:3.1.0"
+        // for run locally Mac Apple M1
+        if (osdetector.os == "osx") {
+          artifact = "com.google.protobuf:protoc:3.1.0:osx-x86_64"
+        } else {
+          artifact = "com.google.protobuf:protoc:3.1.0"
+        }
     }
     plugins {
         grpc {
-            artifact = "io.grpc:protoc-gen-grpc-java:1.0.3"
+            // for run locally Mac Apple M1
+            if (osdetector.os == "osx") {
+                artifact = "io.grpc:protoc-gen-grpc-java:1.0.3:osx-x86_64"
+            } else {
+                artifact = "io.grpc:protoc-gen-grpc-java:1.0.3"
+            }
         }
     }
 

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -47,21 +47,11 @@ dependencies {
 protobuf {
     generatedFilesBaseDir = "${projectDir}/build/protos/"
     protoc {
-        // for build locally Mac Apple M1
-        if (osdetector.os == "osx") {
-          artifact = "com.google.protobuf:protoc:3.1.0:osx-x86_64"
-        } else {
-          artifact = "com.google.protobuf:protoc:3.1.0"
-        }
+        artifact = "com.google.protobuf:protoc:3.1.0"
     }
     plugins {
         grpc {
-            // for build locally Mac Apple M1
-            if (osdetector.os == "osx") {
-                artifact = "io.grpc:protoc-gen-grpc-java:1.0.3:osx-x86_64"
-            } else {
-                artifact = "io.grpc:protoc-gen-grpc-java:1.0.3"
-            }
+            artifact = "io.grpc:protoc-gen-grpc-java:1.0.3"
         }
     }
 

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 protobuf {
     generatedFilesBaseDir = "${projectDir}/build/protos/"
     protoc {
-        // for run locally Mac Apple M1
+        // for build locally Mac Apple M1
         if (osdetector.os == "osx") {
           artifact = "com.google.protobuf:protoc:3.1.0:osx-x86_64"
         } else {
@@ -56,7 +56,7 @@ protobuf {
     }
     plugins {
         grpc {
-            // for run locally Mac Apple M1
+            // for build locally Mac Apple M1
             if (osdetector.os == "osx") {
                 artifact = "io.grpc:protoc-gen-grpc-java:1.0.3:osx-x86_64"
             } else {


### PR DESCRIPTION
**Background**

Currently, there are two services for data discovery: Meteor and Compass. **Meteor** extracts assets from various sources (e.g., BigQuery tables, Optimus, Firehose, Dagger jobs) and syncs the metadata to **Compass** as the catalog service. However, currently, Compass has a lot of assets that no longer present and not synced. **We need a housekeeping mechanism in Compass to automatically remove stale assets from the database.**

**Goals in this Repo:**
Create proto for delete assets API in Compass

**Idea:**
`DeleteAssets` as DELETE `/v1/assets/`: an async API that will return how many rows that will affect based on filter criteria, and delete those rows from PostgreSQL (assets and lineage) and Elasticsearch in the background.

**Request:**
- `query_expr` represent query expr for filter criteria: [https://github.com/expr-lang/expr](https://github.com/expr-lang/expr).
- `dry_run` represent whether it only return how much affected rows (if set to true), or also perform deletion process in the background (default: false).

**Response:**
`affected_rows` represent how many rows that will affect based on filter criteria.