### PR TITLE
feat: add provider filters to ListApprovalsRequest

### DIFF
--- a/gotocompany/guardian/v1beta1/guardian.proto
+++ b/gotocompany/guardian/v1beta1/guardian.proto
@@ -708,6 +708,8 @@ message ListApprovalsRequest {
   string role_ends_with = 13;
   string role_contains = 14;
   repeated string step_names = 15;
+  repeated string provider_types = 16;
+  repeated string provider_urns = 17;
 }
 
 message ListApprovalsResponse {


### PR DESCRIPTION
Introduced repeated fields 'provider_types' and 'provider_urns' to ListApprovalsRequest in guardian.proto to enable filtering approvals by provider type and URN.