### PR TITLE
feat: support approval_actor field to approval request messages

### DIFF
--- a/gotocompany/guardian/v1beta1/guardian.proto
+++ b/gotocompany/guardian/v1beta1/guardian.proto
@@ -696,7 +696,7 @@ message ListUserApprovalsRequest {
   repeated string step_names = 15;
   repeated string provider_types = 16;
   repeated string provider_urns = 17;
-  repeated string approval_actor = 18;
+  repeated string actors = 18;
 }
 
 message ListUserApprovalsResponse {


### PR DESCRIPTION
Introduces the approval_actor string field to ListUserApprovalsRequest and ListApprovalsRequest messages in guardian.proto to allow filtering or specifying the actor involved in approval processes.