### PR TITLE
feat: add new filter and appeal exclusion flags

### DIFF
--- a/gotocompany/guardian/v1beta1/guardian.proto
+++ b/gotocompany/guardian/v1beta1/guardian.proto
@@ -1163,6 +1163,7 @@ message ListGrantsRequest {
   bool summary_labels_v2 = 63;
   bool exclude_empty_appeal = 64;
   InactiveGrantPolicy inactive_grant_policy = 65;
+  InactiveGrantPolicy inactive_grant_group_id = 66;
 }
 
 message ListGrantsResponse {

--- a/gotocompany/guardian/v1beta1/guardian.proto
+++ b/gotocompany/guardian/v1beta1/guardian.proto
@@ -1086,10 +1086,13 @@ message ListGrantsRequest {
     // This is the default behavior if no policy is specified.
     INACTIVE_GRANT_POLICY_INCLUDE_ALL = 1;
 
-    // Smart visibility mode:
-    // - If X-Auth-Email not provided it will fallback to INACTIVE_GRANT_POLICY_UNSPECIFIED behaviour.
-    // - If a resource has both active and inactive grants, only active ones are shown.
-    // - If all grants for a resource are inactive, only the latest inactive grant is returned.
+    // Smart deduplication mode scoped to a group, resource, or provider.
+    // Requires at least one of: inactive_grant_group_id, inactive_grant_group_type,
+    // inactive_grant_resource_id, or inactive_grant_provider_type to be set.
+    // - If a grant key (resource + account + role) has both active and inactive grants,
+    //   only the active ones are shown (inactive are excluded).
+    // - If all grants for a key are inactive, only the latest inactive grant is returned;
+    //   older duplicates are excluded.
     INACTIVE_GRANT_POLICY_SMART = 2;
   }
 
@@ -1163,9 +1166,14 @@ message ListGrantsRequest {
   bool summary_labels_v2 = 63;
   bool exclude_empty_appeal = 64;
   InactiveGrantPolicy inactive_grant_policy = 65;
+  // Scope for INACTIVE_GRANT_POLICY_SMART: filter by grant's group_id.
+  // At least one scope field must be set when using SMART policy.
   string inactive_grant_group_id = 66;
+  // Scope for INACTIVE_GRANT_POLICY_SMART: filter by grant's group_type.
   string inactive_grant_group_type = 67;
+  // Scope for INACTIVE_GRANT_POLICY_SMART: filter by grant's resource_id.
   string inactive_grant_resource_id = 68;
+  // Scope for INACTIVE_GRANT_POLICY_SMART: filter by grant's provider_type.
   string inactive_grant_provider_type = 69;
 }
 
@@ -1185,9 +1193,12 @@ message ListUserGrantsRequest {
     // This is the default behavior if no policy is specified.
     INACTIVE_GRANT_POLICY_INCLUDE_ALL = 1;
 
-    // Smart visibility mode:
-    // - If a resource has both active and inactive grants, only active ones are shown.
-    // - If all grants for a resource are inactive, only the latest inactive grant is returned.
+    // Smart deduplication mode scoped to the authenticated user (X-Auth-Email).
+    // - If X-Auth-Email is not provided, the request will fail with Unauthenticated.
+    // - If a grant key (resource + account + role) has both active and inactive grants
+    //   for this user, only the active ones are shown (inactive are excluded).
+    // - If all grants for a key are inactive, only the latest inactive grant is returned;
+    //   older duplicates are excluded.
     INACTIVE_GRANT_POLICY_SMART = 2;
   }
 

--- a/gotocompany/guardian/v1beta1/guardian.proto
+++ b/gotocompany/guardian/v1beta1/guardian.proto
@@ -1163,8 +1163,10 @@ message ListGrantsRequest {
   bool summary_labels_v2 = 63;
   bool exclude_empty_appeal = 64;
   InactiveGrantPolicy inactive_grant_policy = 65;
-  InactiveGrantPolicy inactive_grant_group_id = 66;
-  InactiveGrantPolicy inactive_grant_resource_id = 67;
+  string inactive_grant_group_id = 66;
+  string inactive_grant_group_type = 67;
+  string inactive_grant_resource_id = 68;
+  string inactive_grant_provider_type = 69;
 }
 
 message ListGrantsResponse {

--- a/gotocompany/guardian/v1beta1/guardian.proto
+++ b/gotocompany/guardian/v1beta1/guardian.proto
@@ -1164,6 +1164,7 @@ message ListGrantsRequest {
   bool exclude_empty_appeal = 64;
   InactiveGrantPolicy inactive_grant_policy = 65;
   InactiveGrantPolicy inactive_grant_group_id = 66;
+  InactiveGrantPolicy inactive_grant_resource_id = 67;
 }
 
 message ListGrantsResponse {

--- a/gotocompany/guardian/v1beta1/guardian.proto
+++ b/gotocompany/guardian/v1beta1/guardian.proto
@@ -640,6 +640,7 @@ message ListUserAppealsRequest {
   map<string, LabelValues> labels = 56;
   repeated string label_keys = 57;
   bool summary_labels = 58;
+  bool summary_labels_v2 = 59;
 }
 
 message ListUserAppealsResponse {
@@ -715,6 +716,7 @@ message ListAppealsRequest {
   repeated string details_for_self_criteria = 58;
   repeated string not_details_for_self_criteria = 59;
   bool summary_labels = 60;
+  bool summary_labels_v2 = 61;
 }
 
 message ListAppealsResponse {
@@ -911,6 +913,7 @@ message ListUserApprovalsRequest {
   map<string, LabelValues> labels = 59;
   repeated string label_keys = 60;
   bool summary_labels = 61;
+  bool summary_labels_v2 = 62;
 }
 
 message ListUserApprovalsResponse {
@@ -987,6 +990,7 @@ message ListApprovalsRequest {
   map<string, LabelValues> labels = 59;
   repeated string label_keys = 60;
   bool summary_labels = 61;
+  bool summary_labels_v2 = 62;
 }
 
 message ListApprovalsResponse {
@@ -1073,6 +1077,22 @@ message UpdateApprovalStepResponse {
 }
 
 message ListGrantsRequest {
+  enum InactiveGrantPolicy {
+    // Unspecified behavior. Defaults to INCLUDE_ALL.
+    // The server should treat this as INACTIVE_GRANT_POLICY_INCLUDE_ALL.
+    INACTIVE_GRANT_POLICY_UNSPECIFIED = 0;
+
+    // Include all grants, both active and inactive.
+    // This is the default behavior if no policy is specified.
+    INACTIVE_GRANT_POLICY_INCLUDE_ALL = 1;
+
+    // Smart visibility mode:
+    // - If X-Auth-Email not provided it will fallback to INACTIVE_GRANT_POLICY_UNSPECIFIED behaviour.
+    // - If a resource has both active and inactive grants, only active ones are shown.
+    // - If all grants for a resource are inactive, only the latest inactive grant is returned.
+    INACTIVE_GRANT_POLICY_SMART = 2;
+  }
+
   repeated string statuses = 1;
   repeated string account_ids = 2;
   repeated string account_types = 3;
@@ -1140,6 +1160,9 @@ message ListGrantsRequest {
   map<string, LabelValues> labels = 60;
   repeated string label_keys = 61;
   bool summary_labels = 62;
+  bool summary_labels_v2 = 63;
+  bool exclude_empty_appeal = 64;
+  InactiveGrantPolicy inactive_grant_policy = 65;
 }
 
 message ListGrantsResponse {
@@ -1227,6 +1250,8 @@ message ListUserGrantsRequest {
   map<string, LabelValues> labels = 55;
   repeated string label_keys = 56;
   bool summary_labels = 57;
+  bool summary_labels_v2 = 58;
+  bool exclude_empty_appeal = 59;
 }
 
 message ListUserGrantsResponse {

--- a/gotocompany/guardian/v1beta1/guardian.proto
+++ b/gotocompany/guardian/v1beta1/guardian.proto
@@ -640,6 +640,7 @@ message ListUserAppealsRequest {
   map<string, LabelValues> labels = 56;
   repeated string label_keys = 57;
   bool summary_labels = 58;
+  bool include_filters_to_labels = 59;
 }
 
 message ListUserAppealsResponse {
@@ -715,6 +716,7 @@ message ListAppealsRequest {
   repeated string details_for_self_criteria = 58;
   repeated string not_details_for_self_criteria = 59;
   bool summary_labels = 60;
+  bool include_filters_to_labels = 61;
 }
 
 message ListAppealsResponse {
@@ -911,6 +913,7 @@ message ListUserApprovalsRequest {
   map<string, LabelValues> labels = 59;
   repeated string label_keys = 60;
   bool summary_labels = 61;
+  bool include_filters_to_labels = 62;
 }
 
 message ListUserApprovalsResponse {
@@ -987,6 +990,7 @@ message ListApprovalsRequest {
   map<string, LabelValues> labels = 59;
   repeated string label_keys = 60;
   bool summary_labels = 61;
+  bool include_filters_to_labels = 62;
 }
 
 message ListApprovalsResponse {
@@ -1140,6 +1144,8 @@ message ListGrantsRequest {
   map<string, LabelValues> labels = 60;
   repeated string label_keys = 61;
   bool summary_labels = 62;
+  bool include_filters_to_labels = 63;
+  bool exclude_empty_appeal = 64;
 }
 
 message ListGrantsResponse {
@@ -1227,6 +1233,8 @@ message ListUserGrantsRequest {
   map<string, LabelValues> labels = 55;
   repeated string label_keys = 56;
   bool summary_labels = 57;
+  bool include_filters_to_labels = 58;
+  bool exclude_empty_appeal = 59;
 }
 
 message ListUserGrantsResponse {

--- a/gotocompany/guardian/v1beta1/guardian.proto
+++ b/gotocompany/guardian/v1beta1/guardian.proto
@@ -640,7 +640,6 @@ message ListUserAppealsRequest {
   map<string, LabelValues> labels = 56;
   repeated string label_keys = 57;
   bool summary_labels = 58;
-  bool include_filters_to_labels = 59;
 }
 
 message ListUserAppealsResponse {
@@ -716,7 +715,6 @@ message ListAppealsRequest {
   repeated string details_for_self_criteria = 58;
   repeated string not_details_for_self_criteria = 59;
   bool summary_labels = 60;
-  bool include_filters_to_labels = 61;
 }
 
 message ListAppealsResponse {
@@ -913,7 +911,6 @@ message ListUserApprovalsRequest {
   map<string, LabelValues> labels = 59;
   repeated string label_keys = 60;
   bool summary_labels = 61;
-  bool include_filters_to_labels = 62;
 }
 
 message ListUserApprovalsResponse {
@@ -990,7 +987,6 @@ message ListApprovalsRequest {
   map<string, LabelValues> labels = 59;
   repeated string label_keys = 60;
   bool summary_labels = 61;
-  bool include_filters_to_labels = 62;
 }
 
 message ListApprovalsResponse {
@@ -1144,8 +1140,6 @@ message ListGrantsRequest {
   map<string, LabelValues> labels = 60;
   repeated string label_keys = 61;
   bool summary_labels = 62;
-  bool include_filters_to_labels = 63;
-  bool exclude_empty_appeal = 64;
 }
 
 message ListGrantsResponse {
@@ -1233,8 +1227,6 @@ message ListUserGrantsRequest {
   map<string, LabelValues> labels = 55;
   repeated string label_keys = 56;
   bool summary_labels = 57;
-  bool include_filters_to_labels = 58;
-  bool exclude_empty_appeal = 59;
 }
 
 message ListUserGrantsResponse {


### PR DESCRIPTION
This pull request updates the `guardian.proto` file to add new filtering and summary options for listing appeals, approvals, and grants. The main changes introduce new fields to support an improved summary labels mechanism, additional grant filtering, and enhanced control over inactive grant visibility.

**Enhancements to summary labels:**
* Added a `summary_labels_v2` boolean field to the following request messages: `ListUserAppealsRequest`, `ListAppealsRequest`, `ListUserApprovalsRequest`, `ListApprovalsRequest`, `ListGrantsRequest`, and `ListUserGrantsRequest`, enabling a new version of summary label handling. [[1]](diffhunk://#diff-0ae30c7ca5e341468be9c03dbb37b6b6ab9afe633352e8ca5f20552f677b0748R643) [[2]](diffhunk://#diff-0ae30c7ca5e341468be9c03dbb37b6b6ab9afe633352e8ca5f20552f677b0748R719) [[3]](diffhunk://#diff-0ae30c7ca5e341468be9c03dbb37b6b6ab9afe633352e8ca5f20552f677b0748R916) [[4]](diffhunk://#diff-0ae30c7ca5e341468be9c03dbb37b6b6ab9afe633352e8ca5f20552f677b0748R993) [[5]](diffhunk://#diff-0ae30c7ca5e341468be9c03dbb37b6b6ab9afe633352e8ca5f20552f677b0748R1163-R1169) [[6]](diffhunk://#diff-0ae30c7ca5e341468be9c03dbb37b6b6ab9afe633352e8ca5f20552f677b0748R1257-R1258)

**Grant filtering and visibility options:**
* Introduced an `exclude_empty_appeal` boolean field to `ListGrantsRequest` and `ListUserGrantsRequest`, allowing exclusion of grants without appeals. [[1]](diffhunk://#diff-0ae30c7ca5e341468be9c03dbb37b6b6ab9afe633352e8ca5f20552f677b0748R1163-R1169) [[2]](diffhunk://#diff-0ae30c7ca5e341468be9c03dbb37b6b6ab9afe633352e8ca5f20552f677b0748R1257-R1258)
* Added an `InactiveGrantPolicy` enum to `ListGrantsRequest` for fine-grained control over inclusion and visibility of inactive grants, with options for including all, smart visibility, or default behavior. [[1]](diffhunk://#diff-0ae30c7ca5e341468be9c03dbb37b6b6ab9afe633352e8ca5f20552f677b0748R1080-R1095) [[2]](diffhunk://#diff-0ae30c7ca5e341468be9c03dbb37b6b6ab9afe633352e8ca5f20552f677b0748R1163-R1169)
* Added fields to `ListGrantsRequest` for filtering by inactive grant group, type, resource, and provider: `inactive_grant_group_id`, `inactive_grant_group_type`, `inactive_grant_resource_id`, and `inactive_grant_provider_type`.

These changes provide greater flexibility and control for clients interacting with the Guardian API, especially around label summaries and grant visibility.