### PR TITLE
feat(guardian): add summary_labels_v2 to list request messages

### DIFF
--- a/gotocompany/guardian/v1beta1/guardian.proto
+++ b/gotocompany/guardian/v1beta1/guardian.proto
@@ -640,6 +640,7 @@ message ListUserAppealsRequest {
   map<string, LabelValues> labels = 56;
   repeated string label_keys = 57;
   bool summary_labels = 58;
+  bool summary_labels_v2 = 59;
 }
 
 message ListUserAppealsResponse {
@@ -715,6 +716,7 @@ message ListAppealsRequest {
   repeated string details_for_self_criteria = 58;
   repeated string not_details_for_self_criteria = 59;
   bool summary_labels = 60;
+  bool summary_labels_v2 = 61;
 }
 
 message ListAppealsResponse {
@@ -911,6 +913,7 @@ message ListUserApprovalsRequest {
   map<string, LabelValues> labels = 59;
   repeated string label_keys = 60;
   bool summary_labels = 61;
+  bool summary_labels_v2 = 62;
 }
 
 message ListUserApprovalsResponse {
@@ -987,6 +990,7 @@ message ListApprovalsRequest {
   map<string, LabelValues> labels = 59;
   repeated string label_keys = 60;
   bool summary_labels = 61;
+  bool summary_labels_v2 = 62;
 }
 
 message ListApprovalsResponse {
@@ -1140,6 +1144,7 @@ message ListGrantsRequest {
   map<string, LabelValues> labels = 60;
   repeated string label_keys = 61;
   bool summary_labels = 62;
+  bool summary_labels_v2 = 63;
 }
 
 message ListGrantsResponse {
@@ -1227,6 +1232,7 @@ message ListUserGrantsRequest {
   map<string, LabelValues> labels = 55;
   repeated string label_keys = 56;
   bool summary_labels = 57;
+  bool summary_labels_v2 = 58;
 }
 
 message ListUserGrantsResponse {

--- a/gotocompany/guardian/v1beta1/guardian.proto
+++ b/gotocompany/guardian/v1beta1/guardian.proto
@@ -640,7 +640,7 @@ message ListUserAppealsRequest {
   map<string, LabelValues> labels = 56;
   repeated string label_keys = 57;
   bool summary_labels = 58;
-  // If true, includes label summaries (v2) in the response, grouped by label key with aggregated values and count. Mutually exclusive with summary_labels.
+  // If true, includes label summaries using faceted search: for each label key, available values are computed by applying all other active label filters except that key. Mutually exclusive with summary_labels.
   bool summary_labels_v2 = 59;
 }
 
@@ -717,7 +717,7 @@ message ListAppealsRequest {
   repeated string details_for_self_criteria = 58;
   repeated string not_details_for_self_criteria = 59;
   bool summary_labels = 60;
-  // If true, includes label summaries (v2) in the response, grouped by label key with aggregated values and count. Mutually exclusive with summary_labels.
+  // If true, includes label summaries using faceted search: for each label key, available values are computed by applying all other active label filters except that key. Mutually exclusive with summary_labels.
   bool summary_labels_v2 = 61;
 }
 
@@ -915,7 +915,7 @@ message ListUserApprovalsRequest {
   map<string, LabelValues> labels = 59;
   repeated string label_keys = 60;
   bool summary_labels = 61;
-  // If true, includes label summaries (v2) in the response, grouped by label key with aggregated values and count. Mutually exclusive with summary_labels.
+  // If true, includes label summaries using faceted search: for each label key, available values are computed by applying all other active label filters except that key. Mutually exclusive with summary_labels.
   bool summary_labels_v2 = 62;
 }
 
@@ -993,7 +993,7 @@ message ListApprovalsRequest {
   map<string, LabelValues> labels = 59;
   repeated string label_keys = 60;
   bool summary_labels = 61;
-  // If true, includes label summaries (v2) in the response, grouped by label key with aggregated values and count. Mutually exclusive with summary_labels.
+  // If true, includes label summaries using faceted search: for each label key, available values are computed by applying all other active label filters except that key. Mutually exclusive with summary_labels.
   bool summary_labels_v2 = 62;
 }
 
@@ -1167,7 +1167,7 @@ message ListGrantsRequest {
   map<string, LabelValues> labels = 60;
   repeated string label_keys = 61;
   bool summary_labels = 62;
-  // If true, includes label summaries (v2) in the response, grouped by label key with aggregated values and count. Mutually exclusive with summary_labels.
+  // If true, includes label summaries using faceted search: for each label key, available values are computed by applying all other active label filters except that key. Mutually exclusive with summary_labels.
   bool summary_labels_v2 = 63;
   bool exclude_empty_appeal = 64;
   InactiveGrantPolicy inactive_grant_policy = 65;
@@ -1262,7 +1262,7 @@ message ListUserGrantsRequest {
   map<string, LabelValues> labels = 55;
   repeated string label_keys = 56;
   bool summary_labels = 57;
-  // If true, includes label summaries (v2) in the response, grouped by label key with aggregated values and count. Mutually exclusive with summary_labels.
+  // If true, includes label summaries using faceted search: for each label key, available values are computed by applying all other active label filters except that key. Mutually exclusive with summary_labels.
   bool summary_labels_v2 = 58;
   bool exclude_empty_appeal = 59;
 }

--- a/gotocompany/guardian/v1beta1/guardian.proto
+++ b/gotocompany/guardian/v1beta1/guardian.proto
@@ -640,6 +640,7 @@ message ListUserAppealsRequest {
   map<string, LabelValues> labels = 56;
   repeated string label_keys = 57;
   bool summary_labels = 58;
+  // If true, includes label summaries (v2) in the response, grouped by label key with aggregated values and count. Mutually exclusive with summary_labels.
   bool summary_labels_v2 = 59;
 }
 
@@ -716,6 +717,7 @@ message ListAppealsRequest {
   repeated string details_for_self_criteria = 58;
   repeated string not_details_for_self_criteria = 59;
   bool summary_labels = 60;
+  // If true, includes label summaries (v2) in the response, grouped by label key with aggregated values and count. Mutually exclusive with summary_labels.
   bool summary_labels_v2 = 61;
 }
 
@@ -913,6 +915,7 @@ message ListUserApprovalsRequest {
   map<string, LabelValues> labels = 59;
   repeated string label_keys = 60;
   bool summary_labels = 61;
+  // If true, includes label summaries (v2) in the response, grouped by label key with aggregated values and count. Mutually exclusive with summary_labels.
   bool summary_labels_v2 = 62;
 }
 
@@ -990,6 +993,7 @@ message ListApprovalsRequest {
   map<string, LabelValues> labels = 59;
   repeated string label_keys = 60;
   bool summary_labels = 61;
+  // If true, includes label summaries (v2) in the response, grouped by label key with aggregated values and count. Mutually exclusive with summary_labels.
   bool summary_labels_v2 = 62;
 }
 
@@ -1163,6 +1167,7 @@ message ListGrantsRequest {
   map<string, LabelValues> labels = 60;
   repeated string label_keys = 61;
   bool summary_labels = 62;
+  // If true, includes label summaries (v2) in the response, grouped by label key with aggregated values and count. Mutually exclusive with summary_labels.
   bool summary_labels_v2 = 63;
   bool exclude_empty_appeal = 64;
   InactiveGrantPolicy inactive_grant_policy = 65;
@@ -1257,6 +1262,7 @@ message ListUserGrantsRequest {
   map<string, LabelValues> labels = 55;
   repeated string label_keys = 56;
   bool summary_labels = 57;
+  // If true, includes label summaries (v2) in the response, grouped by label key with aggregated values and count. Mutually exclusive with summary_labels.
   bool summary_labels_v2 = 58;
   bool exclude_empty_appeal = 59;
 }


### PR DESCRIPTION
## Summary

Adds `summary_labels_v2` boolean field to all 6 list request messages:
- `ListUserAppealsRequest` (field 59)
- `ListAppealsRequest` (field 61)
- `ListUserApprovalsRequest` (field 62)
- `ListApprovalsRequest` (field 62)
- `ListGrantsRequest` (field 63)
- `ListUserGrantsRequest` (field 58)

When set to `true`, enables faceted label search — for each label key K, available values are derived by applying all OTHER active label filters (excluding K).

## Related
- Corresponding guardian implementation: `goto/guardian#bearaujus/patch-35`
